### PR TITLE
ADMIN_MEDIA_PREFIX is not always set on Django 1.4

### DIFF
--- a/linkcheck/tests/__init__.py
+++ b/linkcheck/tests/__init__.py
@@ -48,6 +48,7 @@ def mock_urlopen(url, data=None, timeout=timeout):
     raise urllib2.HTTPError(url, code, msg, None, None)
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.test import TestCase
 from linkcheck.models import Url
 
@@ -164,3 +165,13 @@ class FindingLinksTestCase(TestCase):
         Book.objects.create(title='My Title', description="""Here's a link: <a href="http://www.example.org">Example</a>""")
         self.assertEqual(Url.objects.all().count(), 1)
         self.assertEqual(Url.objects.all()[0].url, "http://www.example.org")
+
+class ReportViewTestCase(TestCase):
+    def setUp(self):
+        from django.contrib.auth.models import User
+        User.objects.create_superuser('admin', 'admin@example.org', 'password')
+
+    def test_report_view(self):
+        self.client.login(username='admin', password='password')
+        response = self.client.get(reverse('linkcheck.views.report'))
+        self.assertContains(response, "<h1>Link Checker</h1>")

--- a/linkcheck/views.py
+++ b/linkcheck/views.py
@@ -6,6 +6,7 @@ try:
 except:
     from django.utils import simplejson
     
+from django.contrib.admin.templatetags.adminmedia import admin_media_prefix
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import Paginator
@@ -118,12 +119,13 @@ def report(request):
     if ('page' in rqst):
         del rqst['page']
 
+    admin_static = admin_media_prefix() or settings.STATIC_URL
     return render_to_response(
         'linkcheck/report.html',
             {'content_types_list': content_types_list,
             'pages': links,
             'filter': link_filter,
-            'media':  forms.Media(js=['%s%s' % (settings.ADMIN_MEDIA_PREFIX, 'js/jquery.min.js')]),
+            'media':  forms.Media(js=['%s%s' % (admin_static, 'js/jquery.min.js')]),
             'qry_data': rqst.urlencode(),
             'report_type': report_type,
             'ignored_count': Link.objects.filter(ignore=True).count(),

--- a/runtests.py
+++ b/runtests.py
@@ -8,12 +8,13 @@ from django.conf import settings
 if not settings.configured:
     settings.configure(
         DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3'}},
+        STATIC_URL = '/static/',
         INSTALLED_APPS=[
             'django.contrib.admin', 'django.contrib.auth',
             'django.contrib.sessions', 'django.contrib.contenttypes',
             'linkcheck', 'linkcheck.tests.sampleapp',
         ],
-        ROOT_URLCONF = "",
+        ROOT_URLCONF = "linkcheck.tests.test_urls",
         SITE_DOMAIN = "localhost"
     )
 


### PR DESCRIPTION
I found another incompatibility with Django 1.4. The code should still be compatible with Django 1.2. New test added.
