### PR TITLE
Ignore empty URLFields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 * Python 3 is supported.
 * Django 1.7 / 1.8 compatibility added.
 * notifications.py is now based on django-admin-blocks.
+* Linklist classes now support an ignore_empty list to ignore empty URLField values.
 
 1.0 
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,34 @@ shown in the screenshot above.
 We are aware that this documentation is on the brief side of things so any
 suggestions for elaboration or clarification would be gratefully accepted.
 
+Linklist classes
+----------------
+
+The following class attributes can be added to your ``Linklist`` subclasses to
+customize the extracted links::
+
+    ``object_filter``: a dictionary which will be passed as a filter argument to
+    the ``filter`` applied to the default queryset of the target class. This
+    allows you to filter the objects from which the links will be extracted.
+    (example: ``{'active': True}``)
+
+    ``object_exclude``: a dictionary which will be passed as a filter argument to
+    the ``exclude`` applied to the default queryset of the target class. As with
+    ``object_filter``, this allows you to exclude objects from which the links
+    will be extracted.
+
+    ``html_fields``: a list of field names which will be searched for links.
+
+    ``url_fields``: a list of ``URLField`` field names whose content will be
+    considered as links. If the field content is empty and the field name is
+    in ``ignore_empty``, the content is ignored.
+
+    ``ignore_empty``: a list of fields from ``url_fields``. See the explanation
+    above. (new in django-linkcheck 1.1)
+
+    ``image_fields``: a list of ``ImageField`` field names whose content will be
+    considered as links. Empty ``ImageField`` content is always ignored.
+
 Settings
 --------
 

--- a/linkcheck/__init__.py
+++ b/linkcheck/__init__.py
@@ -97,6 +97,7 @@ class Linklist(object):
 
     html_fields = []
     url_fields = []
+    ignore_empty = []
     image_fields = []
     # You can override object_filter and object_exclude in a linklist class. Just provide a dictionary to be used as a Django lookup filter.
     # Only objects that pass the filter will be queried for links. 
@@ -124,7 +125,10 @@ class Linklist(object):
 
         # Now add in the URL fields
         for field in self.url_fields:
-            urls.append((field, '', getattr(obj ,field)))
+            url_data = (field, '', getattr(obj ,field))
+            if field in self.ignore_empty and not url_data[2]:
+                continue
+            urls.append(url_data)
             
         return urls
 

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -177,6 +177,22 @@ class FindingLinksTestCase(TestCase):
             ["<Url: http://www.example.org>", "<Url: http://www.example.org/logo.png>"]
         )
 
+    def test_empty_url_field(self):
+        """
+        Test that URLField empty content is excluded depending on ignore_empty list.
+        """
+        from linkcheck.models import all_linklists
+        all_linklists['Authors'].ignore_empty = ['website']
+        try:
+            Author.objects.create(name="William Shakespeare")
+            Author.objects.create(name="John Smith", website="http://www.example.org/smith")
+            self.assertEqual(Url.objects.all().count(), 1)
+        finally:
+            all_linklists['Authors'].ignore_empty = []
+        Author.objects.create(name="Alphonse Daudet")
+        # This time, the empty 'website' is extracted
+        self.assertEqual(Url.objects.all().count(), 2)
+
 
 class ReportViewTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
Andy, empty URLFields are currently generating empty Urls objects. Was that on purpose? Is there a use case I'm missing or could this patch be committed?
