### PR TITLE
Show progress dots while rechecking a link

### DIFF
--- a/linkcheck/templates/linkcheck/report.html
+++ b/linkcheck/templates/linkcheck/report.html
@@ -2,6 +2,24 @@
 {% block extrahead %}
 {{ block.super }}
 <script type="text/javascript">
+    function showProgressDots(numberOfDots) {
+        var progress = document.getElementById('progressDots');
+        if (!progress) return;
+        switch(numberOfDots) {
+            case 1:
+                progress.innerHTML = '.&nbsp;&nbsp;';
+                timerHandle = setTimeout('showProgressDots(2)',200);
+                break;
+            case 2:
+                progress.innerHTML = '..&nbsp;';
+                timerHandle = setTimeout('showProgressDots(3)',200);
+                break;
+            case 3:
+                progress.innerHTML = '...';
+                timerHandle = setTimeout('showProgressDots(1)',200);
+                break;
+        }
+    }
 
     $(document).ready(function() {
 
@@ -39,6 +57,8 @@
         });
 
         $(".recheck").submit(function(){
+            $(this).closest('tr').find('td.link_message').html('Checking<span id="progressDots"></span>');
+            showProgressDots(1);
             $.ajax({
                 url: this.action,
                 dataType: 'json',


### PR DESCRIPTION
There is currently no visual feedback that a check is in progress after clicking on Recheck. With this patch, I'm suggesting to display a "Checking..." text in the status box, with changing dots number to better convey the fact that a check is in progress. 
