### PR TITLE
Test external links on a liveserver instance

### DIFF
--- a/linkcheck/tests/sampleapp/views.py
+++ b/linkcheck/tests/sampleapp/views.py
@@ -1,0 +1,9 @@
+from django.http import HttpResponse, HttpResponseRedirect
+
+
+def http_response(request, code):
+    return HttpResponse("", status=int(code))
+
+
+def http_redirect(request, code):
+    return HttpResponseRedirect("/http/200/", status=int(code))

--- a/linkcheck/tests/test_urls.py
+++ b/linkcheck/tests/test_urls.py
@@ -1,10 +1,14 @@
-from django.conf.urls import include, patterns
+from django.conf.urls import include, patterns, url
 from django.contrib import admin
 from django import http
+
+from linkcheck.tests.sampleapp import views
 
 handler404 = lambda x: http.HttpResponseNotFound('')
 
 urlpatterns = patterns('',
-    (r'^admin/linkcheck/', include('linkcheck.urls')),
-    (r'^admin/', include(admin.site.urls)),
+    url(r'^admin/linkcheck/', include('linkcheck.urls')),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^http/(?P<code>\d+)/$', views.http_response),
+    url(r'^http/redirect/(?P<code>\d+)/$', views.http_redirect),
 )


### PR DESCRIPTION
This allows us a better control over responses and prevents requiring an
Internet connection during tests.
