### PR TITLE
Replaced NullBooleanField by BooleanField(null=True)

### DIFF
--- a/linkcheck/migrations/0001_initial.py
+++ b/linkcheck/migrations/0001_initial.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('url', models.CharField(unique=True, max_length=255)),
                 ('last_checked', models.DateTimeField(null=True, blank=True)),
-                ('status', models.NullBooleanField()),
+                ('status', models.BooleanField(null=True)),
                 ('message', models.CharField(max_length=1024, null=True, blank=True)),
                 ('still_exists', models.BooleanField(default=False)),
             ],

--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -61,7 +61,7 @@ class Url(models.Model):
     """
     url = models.CharField(max_length=MAX_URL_LENGTH, unique=True)  # See http://www.boutell.com/newfaq/misc/urllength.html
     last_checked = models.DateTimeField(blank=True, null=True)
-    status = models.NullBooleanField()
+    status = models.BooleanField(null=True)
     message = models.CharField(max_length=1024, blank=True, null=True)
     still_exists = models.BooleanField(default=False)
     redirect_to = models.TextField(blank=True)


### PR DESCRIPTION
NullBooleanField was deprecated in Django 3.1.