### PR TITLE
Ignore raw `pre_save` signal

### DIFF
--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -111,9 +111,9 @@ def delete_instance_links(sender, instance, **kwargs):
     old_links.delete()
 
 
-def instance_pre_save(sender, instance, **kwargs):
-    if not instance.pk:
-        # Ignore unsaved instances
+def instance_pre_save(sender, instance, raw=False, **kwargs):
+    if not instance.pk or raw:
+        # Ignore unsaved instances or raw imports
         return
     current_url = instance.get_absolute_url()
     previous_url = sender.objects.get(pk=instance.pk).get_absolute_url()

--- a/linkcheck/tests/sampleapp/fixture.json
+++ b/linkcheck/tests/sampleapp/fixture.json
@@ -1,0 +1,10 @@
+[
+  {
+    "model": "sampleapp.Book",
+    "pk": 1,
+    "fields": {
+      "title": "My Title",
+      "description": "My description"
+    }
+  }
+]

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -416,3 +416,10 @@ class GetJqueryMinJsTestCase(TestCase):
         self.assertEqual(
             'admin/js/vendor/jquery/jquery.min.js', get_jquery_min_js()
         )
+
+
+class FixtureTestCase(TestCase):
+    fixtures = ['linkcheck/tests/sampleapp/fixture.json']
+
+    def test_fixture(self):
+        self.assertEqual(Book.objects.count(), 1)


### PR DESCRIPTION
This adds support for the `raw` flag to linkcheck's `pre_save` signal.

If the model is saved exactly as presented (i.e. when loading a fixture), one should not query/modify other records in the database as the database might not be in a consistent state yet (see [documentation](https://docs.djangoproject.com/en/3.2/ref/signals/#pre-save)).

This is my first contribution to this repository, so I'm not sure how you would want this change to be represented in the tests. But if you give me a hint, I'm willing to add test cases for this patch.
Thanks in advance for your feedback and help!

Fixes  #106