### PR TITLE
Catch all errors in linkcheck worker, fixes #117

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Unreleased
 
+* Avoid crash when unexpected error in signal listener occurs
+  (Sven Seeberg, #117)
 * Ignore Urls longer than `MAX_URL_LENGTH` in signal listeners
   (Timo Ludwig, #115)
 * Verify SSL certificates (Timo Ludwig, #118)

--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import time
 from contextlib import contextmanager
-from queue import LifoQueue
+from queue import Empty, LifoQueue
 from threading import Thread
 
 from django.apps import apps
@@ -22,10 +22,13 @@ worker_running = False
 tests_running = len(sys.argv) > 1 and sys.argv[1] == 'test' or sys.argv[0].endswith('runtests.py')
 
 
-def linkcheck_worker():
+def linkcheck_worker(block=True):
     global worker_running
     while tasks_queue.not_empty:
-        task = tasks_queue.get()
+        try:
+            task = tasks_queue.get(block=block)
+        except Empty:
+            break
         task['target'](*task['args'], **task['kwargs'])
         tasks_queue.task_done()
     worker_running = False


### PR DESCRIPTION
This PR catches all errors that may arise while calling `do_check_instance_links()` from the worker thread. This should hopefully prevent the worker thread from crashing as it does not do anything else.

If an error occurs, the representation of the instance and other parameters is being logged.

I have to admit that the solution is a little lazy, but I cannot think of a scenario were catching all errors would cause an issue.

This should fix #117