### PR TITLE
Verify SSL certificates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Verify SSL certificates (Timo Ludwig, #118)
 * Added support for Python 3.10/3.11 and Django 4.1.
 * Dropped support for Python 3.6 and Django < 3.2.
 

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -173,6 +173,13 @@ class ExternalCheckTestCase(LiveServerTestCase):
         self.assertEqual(uv.message, '200 OK')
         self.assertEqual(uv.redirect_to, '')
 
+    def test_external_check_200_missing_cert(self):
+        uv = Url(url="%s/http/200/" % self.live_server_url.replace("http://", "https://"), still_exists=True)
+        uv.check_url()
+        self.assertEqual(uv.status, False)
+        self.assertEqual(uv.message, 'SSL Error: wrong version number')
+        self.assertEqual(uv.redirect_to, '')
+
     def test_external_check_200_utf8(self):
         uv = Url(url="%s/http/200/r%%C3%%BCckmeldung/" % self.live_server_url, still_exists=True)
         uv.check_url()


### PR DESCRIPTION
This PR removes the `'verify': False,` option for the checking requests, which should make sure that links with incorrect certificates are marked as invalid.

I don't see a reason why anyone would not want this and would prefer to enforce this, but if you think legacy apps might need the option to turn this off, I could also add a config value for this.

The hard part was to get at least some half-decent readable output from the requests library, unfortunately they seem to just stack their own exceptions on top of all urllib's exceptions in string representation, so I didn't find a way to extract the original exception text from the final exception without ugly regex parsing...

I tested this with a few URLs from https://badssl.com/, and the results seem to look promising:

![Screenshot 2022-11-17 at 16-12-47 Integreat Editorial System](https://user-images.githubusercontent.com/16021269/202484089-5e57dcef-12af-4c9c-afa9-b785a37d49f6.png)

(I didn't know how to test more options with Django's test server other than simply a missing certificate)

Fixes #118