### PR TITLE
Delete outdated objects on `findlinks` command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Unreleased
 
+* Delete outdated `Url` and `Link` objects when
+  running `findlinks` command (Timo Ludwig, #101)
 * Avoid crash when unexpected error in signal listener occurs
   (Sven Seeberg, #117)
 * Ignore Urls longer than `MAX_URL_LENGTH` in signal listeners

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Remove unused field `still_exists` from `Url` model
 * Delete outdated `Url` and `Link` objects when
   running `findlinks` command (Timo Ludwig, #101)
 * Avoid crash when unexpected error in signal listener occurs

--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -104,7 +104,6 @@ def check_instance_links(sender, instance, **kwargs):
                 u, created = Url.objects.get_or_create(url=url)
                 l, created = Link.objects.get_or_create(url=u, field=link[0], text=link[1], content_type=content_type, object_id=instance.pk)
                 new_links.append(l.id)
-                u.still_exists = True
                 if internal_hash:
                     setattr(u, '_internal_hash', internal_hash)
                     setattr(u, '_instance', instance)

--- a/linkcheck/management/commands/findlinks.py
+++ b/linkcheck/management/commands/findlinks.py
@@ -5,10 +5,13 @@ from linkcheck.utils import find_all_links
 
 class Command(BaseCommand):
 
-    help = "Goes through all models registered with Linkcheck and records any links found"
+    help = "Goes through all models registered with Linkcheck, records any new links found and removes all outdated links"
 
     def handle(self, *args, **options):
-        self.stdout.write("Finding all new links...")
-        results = find_all_links()
-        return ("%(urls_created)s new Url object(s), %(links_created)s new Link object(s), "
-                "%(urls_deleted)s Url object(s) deleted") % results
+        self.stdout.write("Updating all links...")
+        return "\n".join(
+            [
+                f"{model.capitalize()}: {', '.join([f'{count} {label}' for label, count in data.items()])}"
+                for model, data in find_all_links().items()
+            ]
+        )

--- a/linkcheck/migrations/0004_remove_url_still_exists.py
+++ b/linkcheck/migrations/0004_remove_url_still_exists.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('linkcheck', '0003_redirect_to_as_textfield'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='url',
+            name='still_exists',
+        ),
+    ]

--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -64,7 +64,6 @@ class Url(models.Model):
     last_checked = models.DateTimeField(blank=True, null=True)
     status = models.BooleanField(null=True)
     message = models.CharField(max_length=1024, blank=True, null=True)
-    still_exists = models.BooleanField(default=False)
     redirect_to = models.TextField(blank=True)
 
     @property

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -73,49 +73,49 @@ class InternalCheckTestCase(TestCase):
         request.urlopen = mock_urlopen
 
     def test_internal_check_mailto(self):
-        uv = Url(url="mailto:nobody", still_exists=True)
+        uv = Url(url="mailto:nobody")
         uv.check_url()
         self.assertEqual(uv.status, None)
         self.assertEqual(uv.message, 'Email link (not automatically checked)')
 
     def test_internal_check_blank(self):
-        uv = Url(url="", still_exists=True)
+        uv = Url(url="")
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message, 'Empty link')
 
     def test_internal_check_anchor(self):
-        uv = Url(url="#some_anchor", still_exists=True)
+        uv = Url(url="#some_anchor")
         uv.check_url()
         self.assertEqual(uv.status, None)
         self.assertEqual(uv.message, 'Link to within the same page (not automatically checked)')
 
     def test_internal_check_view_redirect(self):
-        uv = Url(url="/admin/linkcheck", still_exists=True)
+        uv = Url(url="/admin/linkcheck")
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertIn(uv.message,
             ['This link redirects: code %s (Working redirect)' % status for status in [301, 302]]
         )
-        uv = Url(url="/http/brokenredirect/", still_exists=True)
+        uv = Url(url="/http/brokenredirect/")
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message, 'This link redirects: code 302 (Broken redirect)')
 
     def test_internal_check_found(self):
-        uv = Url(url="/public/", still_exists=True)
+        uv = Url(url="/public/")
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, 'Working internal link')
 
     def test_internal_check_broken_internal_link(self):
-        uv = Url(url="/broken/internal/link", still_exists=True)
+        uv = Url(url="/broken/internal/link")
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message, 'Broken internal link')
 
     def test_internal_check_invalid_url(self):
-        uv = Url(url="invalid/url", still_exists=True)
+        uv = Url(url="invalid/url")
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message, 'Invalid URL')
@@ -123,7 +123,7 @@ class InternalCheckTestCase(TestCase):
     def test_same_page_anchor(self):
         # TODO Make this test
         pass
-        #uv = Url(url="#anchor", still_exists=True)
+        #uv = Url(url="#anchor")
         #uv.check_url()
         #self.assertEqual(uv.status, None)
         #self.assertEqual(uv.message, "")
@@ -138,13 +138,13 @@ class InternalMediaCheckTestCase(TestCase):
         settings.MEDIA_ROOT = self.old_media_root
 
     def test_internal_check_media_missing(self):
-        uv = Url(url="/media/not_found", still_exists=True)
+        uv = Url(url="/media/not_found")
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message, 'Missing Document')
 
     def test_internal_check_media_found(self):
-        uv = Url(url="/media/found", still_exists=True)
+        uv = Url(url="/media/found")
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, 'Working file link')
@@ -153,12 +153,12 @@ class InternalMediaCheckTestCase(TestCase):
         media_file = os.path.join(os.path.dirname(__file__), 'media', 'rückmeldung')
         open(media_file, 'a').close()
         self.addCleanup(os.remove, media_file)
-        uv = Url(url="/media/r%C3%BCckmeldung", still_exists=True)
+        uv = Url(url="/media/r%C3%BCckmeldung")
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, 'Working file link')
         # Also when the url is not encoded
-        uv = Url(url="/media/rückmeldung", still_exists=True)
+        uv = Url(url="/media/rückmeldung")
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, 'Working file link')
@@ -169,77 +169,77 @@ class InternalMediaCheckTestCase(TestCase):
 @override_settings(SITE_DOMAIN='example.com')
 class ExternalCheckTestCase(LiveServerTestCase):
     def test_external_check_200(self):
-        uv = Url(url="%s/http/200/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/200/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, '200 OK')
         self.assertEqual(uv.redirect_to, '')
 
     def test_external_check_200_missing_cert(self):
-        uv = Url(url="%s/http/200/" % self.live_server_url.replace("http://", "https://"), still_exists=True)
+        uv = Url(url="%s/http/200/" % self.live_server_url.replace("http://", "https://"))
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message, 'SSL Error: wrong version number')
         self.assertEqual(uv.redirect_to, '')
 
     def test_external_check_200_utf8(self):
-        uv = Url(url="%s/http/200/r%%C3%%BCckmeldung/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/200/r%%C3%%BCckmeldung/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, '200 OK')
         # Also when the url is not encoded
-        uv = Url(url="%s/http/200/rückmeldung/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/200/rückmeldung/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, '200 OK')
 
     def test_external_check_301(self):
-        uv = Url(url="%s/http/301/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/301/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message.lower(), '301 moved permanently')
         self.assertEqual(uv.redirect_to, '')
 
     def test_external_check_301_followed(self):
-        uv = Url(url="%s/http/redirect/301/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/redirect/301/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, '301 Moved Permanently')
         self.assertEqual(uv.redirect_to, '%s/http/200/' % self.live_server_url)
 
     def test_external_check_302_followed(self):
-        uv = Url(url="%s/http/redirect/302/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/redirect/302/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, '302 Found')
         self.assertEqual(uv.redirect_to, '%s/http/200/' % self.live_server_url)
 
     def test_external_check_404(self):
-        uv = Url(url="%s/whatever/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/whatever/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message.lower(), '404 not found')
 
     def test_external_check_redirect_final_404(self):
-        uv = Url(url="%s/http/redirect_to_404/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/redirect_to_404/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message.lower(), '404 not found')
 
     def test_external_check_get_only(self):
         # An URL that allows GET but not HEAD, linkcheck should fallback on GET.
-        uv = Url(url="%s/http/getonly/405/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/getonly/405/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, '200 OK')
         # Same test with other 40x error
-        uv = Url(url="%s/http/getonly/400/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/http/getonly/400/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, '200 OK')
 
     def test_external_check_timedout(self):
-        uv = Url(url="%s/timeout/" % self.live_server_url, still_exists=True)
+        uv = Url(url="%s/timeout/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, False)
         self.assertEqual(uv.message, 'Other Error: The read operation timed out')

--- a/linkcheck/utils.py
+++ b/linkcheck/utils.py
@@ -92,7 +92,7 @@ def check_links(external_recheck_interval=10080, limit=-1, check_internal=True, 
     Return the number of links effectively checked.
     """
 
-    urls = Url.objects.filter(still_exists=True)
+    urls = Url.objects.all()
 
     # An optimization for when check_internal is False
     if not check_internal:


### PR DESCRIPTION
This changes the `findlinks` command to keep track of all found objects to be able to remove all `Url` and `Link` objects which are not contained in the link lists anymore.

Also, I implemented the change detection without the `still_exists` field, so I removed it (since this seemed to be its only purpose).

Thanks in advance for your feedback!

Fixes #101