### PR TITLE
Improve representation of models

### DIFF
--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -103,6 +103,9 @@ class Url(models.Model):
     def __str__(self):
         return self.url
 
+    def __repr__(self):
+        return f"<Url (id: {self.id}, url: {self.url})>"
+
     @property
     def external(self):
         return EXTERNAL_REGEX.match(self.url)
@@ -359,6 +362,12 @@ class Link(models.Model):
             if url_part == absolute_url:
                 return '#' + anchor_part
         return self.url.url
+
+    def __str__(self):
+        return f"{self.url.url} ({self.content_object})"
+
+    def __repr__(self):
+        return f"<Link (id: {self.id}, url: {self.url!r}, source: {self.content_object!r})>"
 
 
 def link_post_delete(sender, instance, **kwargs):

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -245,6 +245,31 @@ class ExternalCheckTestCase(LiveServerTestCase):
         self.assertEqual(uv.message, 'Other Error: The read operation timed out')
 
 
+class ModelTestCase(TestCase):
+
+    def test_str(self):
+        Author.objects.create(name="John Smith", website="http://www.example.org/smith")
+        self.assertEqual(
+            str(Url.objects.first()),
+            "http://www.example.org/smith",
+        )
+        self.assertEqual(
+            str(Link.objects.first()),
+            "http://www.example.org/smith (Author object (1))",
+        )
+
+    def test_repr(self):
+        Author.objects.create(name="John Smith", website="http://www.example.org/smith")
+        self.assertEqual(
+            repr(Url.objects.first()),
+            "<Url (id: 1, url: http://www.example.org/smith)>",
+        )
+        self.assertEqual(
+            repr(Link.objects.first()),
+            "<Link (id: 1, url: <Url (id: 1, url: http://www.example.org/smith)>, source: <Author: Author object (1)>)>",
+        )
+
+
 class ChecklinksTestCase(TestCase):
     def setUp(self):
         request.urlopen = mock_urlopen


### PR DESCRIPTION
I'm not sure whether you agree on this, but sometimes when I work with the Django shell, it would make my life easier if the models would have a more informative representation (at the moment they use Django's default `<Link: Link object (1)>` etc)...