### PR TITLE
Fix incorrect message when redirect has broken anchor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Unreleased
 
+* Fix incorrect message when redirect has broken anchor
+  (Timo Ludwig, #128)
 * Breaking change: Treat broken hash anchors as valid
   unless `LINKCHECK_TOLERATE_BROKEN_ANCHOR` is manually
   set to `False` (Timo Ludwig, #98)

--- a/linkcheck/tests/sampleapp/views.py
+++ b/linkcheck/tests/sampleapp/views.py
@@ -26,3 +26,7 @@ def timeout(request):
 
 def http_response_with_anchor(request):
     return HttpResponse("<html><body><h1 id='anchor'>Anchor</h1></body></html>")
+
+
+def http_redirect_to_anchor(request):
+    return HttpResponseRedirect("/http/anchor/")

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -49,32 +49,49 @@ class InternalCheckTestCase(TestCase):
         uv = Url(url="/http/anchor/#anchor")
         uv.check_url()
         self.assertEqual(uv.status, True)
-        self.assertEqual(uv.message, "Working internal hash anchor")
+        self.assertEqual(uv.message, "Working internal link, working internal hash anchor")
 
     @patch("linkcheck.models.TOLERATE_BROKEN_ANCHOR", False)
     def test_broken_internal_anchor(self):
         uv = Url(url="/http/anchor/#broken-anchor")
         uv.check_url()
         self.assertEqual(uv.status, False)
-        self.assertEqual(uv.message, "Broken internal hash anchor")
+        self.assertEqual(uv.message, "Working internal link, broken internal hash anchor")
 
     def test_broken_internal_anchor_tolerated(self):
         uv = Url(url="/http/anchor/#broken-anchor")
         uv.check_url()
         self.assertEqual(uv.status, True)
-        self.assertEqual(uv.message, "Page OK, but broken internal hash anchor")
+        self.assertEqual(uv.message, "Working internal link, broken internal hash anchor")
+
+    def test_redirect_working_internal_anchor(self):
+        uv = Url(url="/http/redirect_to_anchor/#anchor")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, "Working temporary redirect, working internal hash anchor")
+
+    @patch("linkcheck.models.TOLERATE_BROKEN_ANCHOR", False)
+    def test_redirect_broken_internal_anchor(self):
+        uv = Url(url="/http/redirect_to_anchor/#broken-anchor")
+        uv.check_url()
+        self.assertEqual(uv.status, False)
+        self.assertEqual(uv.message, "Working temporary redirect, broken internal hash anchor")
+
+    def test_redirect_broken_internal_anchor_tolerated(self):
+        uv = Url(url="/http/redirect_to_anchor/#broken-anchor")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, "Working temporary redirect, broken internal hash anchor")
 
     def test_internal_check_view_redirect(self):
         uv = Url(url="/admin/linkcheck")
         uv.check_url()
         self.assertEqual(uv.status, True)
-        self.assertIn(uv.message,
-            ['This link redirects: code %s (Working redirect)' % status for status in [301, 302]]
-        )
+        self.assertEqual(uv.message, "Working temporary redirect")
         uv = Url(url="/http/brokenredirect/")
         uv.check_url()
         self.assertEqual(uv.status, False)
-        self.assertEqual(uv.message, 'This link redirects: code 302 (Broken redirect)')
+        self.assertEqual(uv.message, 'Broken temporary redirect')
 
     def test_internal_check_found(self):
         uv = Url(url="/public/")
@@ -161,7 +178,7 @@ class ExternalCheckTestCase(LiveServerTestCase):
         uv = Url(url="%s/http/301/" % self.live_server_url)
         uv.check_url()
         self.assertEqual(uv.status, False)
-        self.assertEqual(uv.message.lower(), '301 moved permanently')
+        self.assertEqual(uv.message, '301 Moved Permanently')
         self.assertEqual(uv.redirect_to, '')
 
     def test_external_check_301_followed(self):
@@ -212,20 +229,39 @@ class ExternalCheckTestCase(LiveServerTestCase):
         uv = Url(url=f"{self.live_server_url}/http/anchor/#anchor")
         uv.check_url()
         self.assertEqual(uv.status, True)
-        self.assertEqual(uv.message, "Working external hash anchor")
+        self.assertEqual(uv.message, "200 OK, working external hash anchor")
 
     @patch("linkcheck.models.TOLERATE_BROKEN_ANCHOR", False)
     def test_broken_external_anchor(self):
         uv = Url(url=f"{self.live_server_url}/http/anchor/#broken-anchor")
         uv.check_url()
         self.assertEqual(uv.status, False)
-        self.assertEqual(uv.message, "Broken external hash anchor")
+        self.assertEqual(uv.message, "200 OK, broken external hash anchor")
 
     def test_broken_external_anchor_tolerated(self):
         uv = Url(url=f"{self.live_server_url}/http/anchor/#broken-anchor")
         uv.check_url()
         self.assertEqual(uv.status, True)
-        self.assertEqual(uv.message, "Page OK, but broken external hash anchor")
+        self.assertEqual(uv.message, "200 OK, broken external hash anchor")
+
+    def test_redirect_working_external_anchor(self):
+        uv = Url(url=f"{self.live_server_url}/http/redirect_to_anchor/#anchor")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, "302 Found, working external hash anchor")
+
+    @patch("linkcheck.models.TOLERATE_BROKEN_ANCHOR", False)
+    def test_redirect_broken_external_anchor(self):
+        uv = Url(url=f"{self.live_server_url}/http/redirect_to_anchor/#broken-anchor")
+        uv.check_url()
+        self.assertEqual(uv.status, False)
+        self.assertEqual(uv.message, "302 Found, broken external hash anchor")
+
+    def test_redirect_broken_external_anchor_tolerated(self):
+        uv = Url(url=f"{self.live_server_url}/http/redirect_to_anchor/#broken-anchor")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, "302 Found, broken external hash anchor")
 
 
 class ModelTestCase(TestCase):

--- a/linkcheck/tests/urls.py
+++ b/linkcheck/tests/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path('http/getonly/<int:code>/', views.http_response_get_only),
     path('http/redirect/<int:code>/', views.http_redirect),
     path('http/redirect_to_404/', views.http_redirect_to_404),
+    path('http/redirect_to_anchor/', views.http_redirect_to_anchor),
     path('http/brokenredirect/', RedirectView.as_view(url='/non-existent/')),
     path('http/anchor/', views.http_response_with_anchor),
     path('timeout/', views.timeout),


### PR DESCRIPTION
This changes the message from e.g. `302 Found` to `302 Found, but broken external hash anchor` when a redirect works, but the anchor is not found.

Fixes #128