### PR TITLE
`flake8`: Ignore long lines in migrations directory

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: pip install flake8
       - name: Run flake8
-        run: flake8 --max-line-length=120 linkcheck
+        run: flake8 --max-line-length=120 --per-file-ignores='linkcheck/migrations/*:E501' linkcheck
   isort:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 5.0.4
     hooks:
       - id: flake8
-        args: [--max-line-length=120]
+        args: [--max-line-length=120, --per-file-ignores=linkcheck/migrations/*:E501]
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
In #135, I noticed that Django's generated migrations might have way longer lines than 120 chars.
Without an automated formatter, I think it's better to disable this warning than having to manually add a bunch of line breaks.
Not sure if it makes sense to ignore the whole dir for flake, or to just disable the line length limit.