### PR TITLE
Fix type property for internal URLs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Fix `type` property for internal URLs
 * Fix incorrect message when redirect has broken anchor
   (Timo Ludwig, #128)
 * Breaking change: Treat broken hash anchors as valid

--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -137,8 +137,7 @@ class Url(models.Model):
             elif root_domain.startswith('test.'):
                 root_domain = root_domain[5:]
             internal_exceptions = [
-                'http://' + root_domain, 'http://www.' + root_domain, 'http://test.' + root_domain,
-                'https://' + root_domain, 'https://www.' + root_domain, 'https://test.' + root_domain,
+                f'{protocol}://{sub}{root_domain}' for sub in ['', 'www.', 'test.'] for protocol in ['http', 'https']
             ]
 
         for ex in internal_exceptions:

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -100,6 +100,15 @@ class InternalCheckTestCase(TestCase):
         uv.check_url()
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, 'Working internal link')
+        self.assertEqual(uv.type, 'internal')
+
+    def test_internal_check_with_protocol(self):
+        # "localhost" is configured as SITE_DOMAIN in settings
+        uv = Url(url="http://localhost/public/")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, 'Working internal link')
+        self.assertEqual(uv.type, 'internal')
 
     def test_internal_check_broken_internal_link(self):
         uv = Url(url="/broken/internal/link")


### PR DESCRIPTION
Fixes #141 (see issue description for context info)

The diff renders a bit weird, but basically I moved lines [L123-L149](https://github.com/DjangoAdminHackers/django-linkcheck/blob/a6599a61c11026c3fb394ba9f213a21fea111d30/linkcheck/models.py#L123-L149) into their own property and used this to determine whether a URL is internal or external.

New properties added:
- `internal_url`: contains the processed internal URL (if it is internal), so e.g. http://localhost/public/ is converted to `/public/` is localhost is defined as `SITE_DOMAIN`. If the domain is not internal, it returns `None`.
- `internal`: `True` if `internal_url` is not `None`, else `False`

Fixes properties:
- `external`: This does now work for the case described above
- `type`: This is now fixed and recognized internal URLs