### PR TITLE
Fix error when checking video links with hash anchors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Unreleased
 
+* Fix `NotImplementedError`/`AssertionError` when checking
+  video links with hash anchors (Timo Ludwig, #150)
 * Skip checking of hash anchors for non-html files
 * recheck/ignore/unignore requests were using an obsolete `request.is_ajax` call
   (#147)

--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -378,17 +378,23 @@ class Url(models.Model):
             else:
                 try:
                     names = parse_anchors(html)
+                # Known possible errors include: AssertionError, NotImplementedError, UnicodeDecodeError
+                except Exception as e:
+                    logger.debug(
+                        '%s while parsing anchors: %s',
+                        type(e).__name__,
+                        e
+                    )
+                    self.message += ', failed to parse HTML for anchor'
+                    if not TOLERATE_BROKEN_ANCHOR:
+                        self.status = False
+                else:
                     if self.anchor in names:
                         self.message += f', working {scope} hash anchor'
                     else:
                         self.message += f', broken {scope} hash anchor'
                         if not TOLERATE_BROKEN_ANCHOR:
                             self.status = False
-                except UnicodeDecodeError as e:
-                    logger.debug('UnicodeDecodeError while parsing anchors: %s', e)
-                    self.message += ', failed to parse HTML for anchor'
-                    if not TOLERATE_BROKEN_ANCHOR:
-                        self.status = False
 
 
 class Link(models.Model):

--- a/linkcheck/tests/sampleapp/views.py
+++ b/linkcheck/tests/sampleapp/views.py
@@ -38,4 +38,8 @@ def http_redirect_to_anchor(request):
 
 
 def static_video(request):
-    return HttpResponse(b"", content_type='video/mp4')
+    return HttpResponse(b'', content_type='video/mp4')
+
+
+def static_video_forged_content_type(request):
+    return HttpResponse(b'<![x02\x00\xa0\xcc', content_type='text/html')

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -280,6 +280,12 @@ class ExternalCheckTestCase(LiveServerTestCase):
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, "200 OK")
 
+    def test_forged_video_with_time_anchor(self):
+        uv = Url(url=f"{self.live_server_url}/static-files/fake-video.mp4#t=2.0")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, "200 OK, failed to parse HTML for anchor")
+
 
 class ModelTestCase(TestCase):
 

--- a/linkcheck/tests/urls.py
+++ b/linkcheck/tests/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path('http/anchor/', views.http_response_with_anchor),
     path('timeout/', views.timeout),
     path('static-files/video.mp4', views.static_video),
+    path('static-files/fake-video.mp4', views.static_video_forged_content_type),
 ]


### PR DESCRIPTION
Fix `NotImplementedError`/`AssertionError` when checking video links with hash anchors

I struggled to find/generate a smaller video file for this test case, I ended up with a small excerpt from [this stock video](https://www.pexels.com/video/scientist-looking-through-a-microscope-while-having-a-discussion-with-her-colleague-3196600/), do you think it's already sufficient to not include this file in the [MANIFEST.in](https://github.com/DjangoAdminHackers/django-linkcheck/blob/master/MANIFEST.in), or should I explicitly exclude it? Or do you think the file should be shipped with the package so the tests are complete?

Fixes: #150