### PR TITLE
Skip checking of hash anchors for non-html files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Skip checking of hash anchors for non-html files
 * recheck/ignore/unignore requests were using an obsolete `request.is_ajax` call
   (#147)
 

--- a/linkcheck/tests/sampleapp/views.py
+++ b/linkcheck/tests/sampleapp/views.py
@@ -35,3 +35,7 @@ def http_response_with_anchor(request):
 
 def http_redirect_to_anchor(request):
     return HttpResponseRedirect("/http/anchor/")
+
+
+def static_video(request):
+    return HttpResponse(b"", content_type='video/mp4')

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -274,6 +274,12 @@ class ExternalCheckTestCase(LiveServerTestCase):
         self.assertEqual(uv.status, True)
         self.assertEqual(uv.message, "302 Found, broken external hash anchor")
 
+    def test_video_with_time_anchor(self):
+        uv = Url(url=f"{self.live_server_url}/static-files/video.mp4#t=2.0")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, "200 OK")
+
 
 class ModelTestCase(TestCase):
 

--- a/linkcheck/tests/urls.py
+++ b/linkcheck/tests/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     path('http/brokenredirect/', RedirectView.as_view(url='/non-existent/')),
     path('http/anchor/', views.http_response_with_anchor),
     path('timeout/', views.timeout),
+    path('static-files/video.mp4', views.static_video),
 ]


### PR DESCRIPTION
Only perform HEAD request for binary files