### PR TITLE
Retry with different user agent on `403 Forbidden`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Retry with fallback user agent on forbidden response (Timo Ludwig, #159)
 * Also set `redirect_to` on internal redirects (Timo Ludwig, #163)
 * Add new fields to `Url` model:
   * `status_code`: The HTTP status code of the initial request

--- a/linkcheck/tests/sampleapp/views.py
+++ b/linkcheck/tests/sampleapp/views.py
@@ -1,5 +1,6 @@
 import time
 
+from django.core.exceptions import PermissionDenied
 from django.http import (
     HttpResponse,
     HttpResponsePermanentRedirect,
@@ -14,6 +15,14 @@ def http_response(request, code):
 def http_response_get_only(request, code):
     status = int(code) if request.method == 'HEAD' else 200
     return HttpResponse("", status=status)
+
+
+def http_block_user_agent(request, block_head=False):
+    if block_head and request.method == 'HEAD':
+        return HttpResponse('', status=405)
+    if 'Linkchecker' in request.headers.get('User-Agent', ''):
+        raise PermissionDenied()
+    return HttpResponse('')
 
 
 def http_redirect(request, code):

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -502,6 +502,32 @@ class ExternalCheckTestCase(LiveServerTestCase):
         self.assertEqual(uv.redirect_to, '')
         self.assertEqual(uv.type, 'external')
 
+    def test_external_check_blocked_user_agent(self):
+        uv = Url(url=f"{self.live_server_url}/http/block-user-agent/")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, '200 OK')
+        self.assertEqual(uv.anchor_message, '')
+        self.assertEqual(uv.ssl_status, None)
+        self.assertEqual(uv.ssl_message, 'Insecure link')
+        self.assertEqual(uv.get_status_code_display(), '200 OK')
+        self.assertEqual(uv.get_redirect_status_code_display(), None)
+        self.assertEqual(uv.redirect_to, '')
+        self.assertEqual(uv.type, 'external')
+
+    def test_external_check_blocked_user_agent_blocked_head(self):
+        uv = Url(url=f"{self.live_server_url}/http/block-user-agent/block-head/")
+        uv.check_url()
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.message, '200 OK')
+        self.assertEqual(uv.anchor_message, '')
+        self.assertEqual(uv.ssl_status, None)
+        self.assertEqual(uv.ssl_message, 'Insecure link')
+        self.assertEqual(uv.get_status_code_display(), '200 OK')
+        self.assertEqual(uv.get_redirect_status_code_display(), None)
+        self.assertEqual(uv.redirect_to, '')
+        self.assertEqual(uv.type, 'external')
+
     def test_external_check_timedout(self):
         uv = Url(url=f"{self.live_server_url}/timeout/")
         uv.check_url()

--- a/linkcheck/tests/urls.py
+++ b/linkcheck/tests/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
     path('http/<int:code>/', views.http_response),
     path('http/<int:code>/rückmeldung/', views.http_response),
     path('http/getonly/<int:code>/', views.http_response_get_only),
+    path('http/block-user-agent/', views.http_block_user_agent),
+    path('http/block-user-agent/block-head/', views.http_block_user_agent, {'block_head': True}),
     path('http/redirect/<int:code>/', views.http_redirect),
     path('http/redirect_to_404/', views.http_redirect_to_404),
     path('http/redirect_to_anchor/', views.http_redirect_to_anchor),


### PR DESCRIPTION
Fixes #159

Also adds new settings `LINKCHECK_USER_AGENT` and `LINKCHECK_FALLBACK_USER_AGENT` to customize the user agent header for link checker requests.