### PR TITLE
Remove optimization for internal anchors

### DIFF
--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -91,9 +91,7 @@ def check_instance_links(sender, instance, **kwargs):
             for link in links:
                 # url structure = (field, link text, url)
                 url = link[2]
-                internal_hash = False
                 if url.startswith('#'):
-                    internal_hash = url
                     url = instance.get_absolute_url() + url
 
                 if len(url) > MAX_URL_LENGTH:
@@ -106,9 +104,6 @@ def check_instance_links(sender, instance, **kwargs):
                     url=u, field=link[0], text=link[1], content_type=content_type, object_id=instance.pk
                 )
                 new_links.append(l.id)
-                if internal_hash:
-                    setattr(u, '_internal_hash', internal_hash)
-                    setattr(u, '_instance', instance)
                 u.check_url()
 
             gone_links = old_links.exclude(id__in=new_links)

--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -291,20 +291,6 @@ class Url(models.Model):
             self.status = os.path.exists(path) or os.path.exists(decoded_path)
             self.message = 'Working file link' if self.status else 'Missing Document'
 
-        elif getattr(self, '_internal_hash', False) and getattr(self, '_instance', None):
-            # This is a hash link pointing to itself
-            hash = self._internal_hash
-            instance = self._instance
-            if hash == '#':  # special case, point to #
-                self.message = 'Working internal hash anchor'
-                self.status = True
-            else:
-                hash = hash[1:]  # '#something' => 'something'
-                html_content = ''
-                for field in instance._linklist.html_fields:
-                    html_content += getattr(instance, field, '')
-                self._check_anchor(hash, html_content)
-
         elif self.type == 'internal':
             old_prepend_setting = settings.PREPEND_WWW
             settings.PREPEND_WWW = False


### PR DESCRIPTION
I noticed several problems with the current optimization for relative internal anchors (e.g. `#anchor` links in the content that are converted to `/absolute/internal/url/#anchor`):

1. I forgot to migrate this case to the new usage of `check_anchor()`, so it raises an exception at the moment
2. It does not set the new fields for `status_code` etc...
3. It is untested
4. It overrides the builtin `hash`

Instead of fixing it, I think we can remove this block of code and rely on the following `elif self.type == 'internal':` to handle this case. Making a request with the test client won't be that much slower than checking the model fields manually I guess.