### PR TITLE
Ignore raw `post_save` signal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Ignore raw `post_save` signal (Timo Ludwig, #106).
 * Retry with fallback user agent on forbidden response (Timo Ludwig, #159)
 * Also set `redirect_to` on internal redirects (Timo Ludwig, #163)
 * Add new fields to `Url` model:

--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -156,6 +156,10 @@ def instance_pre_save(sender, instance, raw=False, **kwargs):
 
 
 def instance_post_save(sender, instance, **kwargs):
+    # Ignore raw imports
+    if kwargs.get('raw'):
+        return
+
     def do_instance_post_save(sender, instance, **kwargs):
         current_url = instance.get_absolute_url()
         previous_url = getattr(instance, '__previous_url', None)

--- a/linkcheck/tests/sampleapp/fixture.json
+++ b/linkcheck/tests/sampleapp/fixture.json
@@ -1,5 +1,12 @@
 [
   {
+    "model": "sampleapp.Page",
+    "pk": 1,
+    "fields": {
+      "book": 1
+    }
+  },
+  {
     "model": "sampleapp.Book",
     "pk": 1,
     "fields": {

--- a/linkcheck/tests/sampleapp/linklists.py
+++ b/linkcheck/tests/sampleapp/linklists.py
@@ -1,7 +1,7 @@
 from django.db.models import OuterRef, Subquery
 
 from linkcheck import Linklist
-from linkcheck.tests.sampleapp.models import Author, Book, Journal
+from linkcheck.tests.sampleapp.models import Author, Book, Journal, Page
 
 
 class BookLinklist(Linklist):
@@ -9,6 +9,11 @@ class BookLinklist(Linklist):
     model = Book
     object_filter = {}
     html_fields = ['description']
+
+
+class PageLinklist(Linklist):
+    """ Class to let linkcheck app discover fields containing links """
+    model = Page
 
 
 class AuthorLinklist(Linklist):
@@ -31,6 +36,7 @@ class JournalLinklist(Linklist):
 
 linklists = {
     'Books': BookLinklist,
+    'Pages': PageLinklist,
     'Authors': AuthorLinklist,
     'Journals': JournalLinklist,
 }

--- a/linkcheck/tests/sampleapp/models.py
+++ b/linkcheck/tests/sampleapp/models.py
@@ -9,6 +9,13 @@ class Book(models.Model):
         return f"/book/{self.id}/"
 
 
+class Page(models.Model):
+    book = models.ForeignKey(Book, on_delete=models.CASCADE)
+
+    def get_absolute_url(self):
+        return f"/book/{self.book.id}/{self.id}"
+
+
 class Author(models.Model):
     # This model has purposefully no get_absolute_url
     name = models.CharField(max_length=50)

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -23,7 +23,7 @@ from linkcheck.listeners import (
 from linkcheck.models import Link, Url
 from linkcheck.views import get_jquery_min_js
 
-from .sampleapp.models import Author, Book, Journal
+from .sampleapp.models import Author, Book, Journal, Page
 
 
 @override_settings(ROOT_URLCONF='linkcheck.tests.urls')
@@ -967,6 +967,7 @@ class FixtureTestCase(TestCase):
 
     def test_fixture(self):
         self.assertEqual(Book.objects.count(), 1)
+        self.assertEqual(Page.objects.count(), 1)
 
 
 class FilterCallableTestCase(TestCase):


### PR DESCRIPTION
This is a remnant of #106, I noticed this is not fully resolved yet.

Quoting from the [docs](https://docs.djangoproject.com/en/3.2/ref/signals/#post-save):

> One should not query/modify other records in the database as the database might not be in a consistent state yet.