### PR TITLE
Use f-strings for management commands

### DIFF
--- a/linkcheck/management/commands/checkexternal.py
+++ b/linkcheck/management/commands/checkexternal.py
@@ -27,9 +27,9 @@ class Command(BaseCommand):
         externalinterval = options['externalinterval'] or EXTERNAL_RECHECK_INTERVAL
         limit = options.get('limit', None) or MAX_CHECKS_PER_RUN
 
-        self.stdout.write("Checking all external links that haven't been tested for %s minutes." % externalinterval)
+        self.stdout.write(f"Checking all external links that haven't been tested for {externalinterval} minutes.")
         if limit != -1:
-            self.stdout.write("Will run maximum of %s checks this run." % limit)
+            self.stdout.write(f"Will run maximum of {limit} checks this run.")
 
         check_count = check_links(external_recheck_interval=externalinterval, limit=limit, check_internal=False)
-        return "%s external URLs have been checked." % (check_count)
+        return f"{check_count} external URLs have been checked."

--- a/linkcheck/management/commands/checkinternal.py
+++ b/linkcheck/management/commands/checkinternal.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
         self.stdout.write("Checking all internal links.")
         if limit != -1:
-            self.stdout.write("Will run maximum of %s checks this run." % limit)
+            self.stdout.write(f"Will run maximum of {limit} checks this run.")
 
         check_count = check_links(limit=limit, check_external=False)
-        return "%s internal URLs have been checked." % (check_count)
+        return f"{check_count} internal URLs have been checked."

--- a/linkcheck/management/commands/checklinks.py
+++ b/linkcheck/management/commands/checklinks.py
@@ -27,10 +27,10 @@ class Command(BaseCommand):
         externalinterval = options['externalinterval'] or EXTERNAL_RECHECK_INTERVAL
         limit = options['limit'] or MAX_CHECKS_PER_RUN
 
-        self.stdout.write("Checking all links that haven't been tested for %s minutes." % externalinterval)
+        self.stdout.write(f"Checking all links that haven't been tested for {externalinterval} minutes.")
         if limit != -1:
-            self.stdout.write("Will run maximum of %s checks this run." % limit)
+            self.stdout.write(f"Will run maximum of {limit} checks this run.")
 
         internal_checked = check_links(limit=limit, check_external=False)
         external_checked = check_links(external_recheck_interval=externalinterval, limit=limit, check_internal=False)
-        return "%s internal URLs and %s external URLs have been checked." % (internal_checked, external_checked)
+        return f"{internal_checked} internal URLs and {external_checked} external URLs have been checked."


### PR DESCRIPTION
I initially omitted them in #130 because of the translations, but I only wanted to translate the URL status messages in the UI, not the output of the management commands.