### PR TITLE
Fix internal redirect checker

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Fix internal redirect checker (Timo Ludwig, #180)
 * Fix SSL status of unreachable domains (Timo Ludwig, #184)
 * Fix URL message for internal server errorrs (Timo Ludwig, #182)
 * Add support for Django 4.2


### PR DESCRIPTION
Unfortunately, I could not reproduce the problem in tests, only in production.
So I also failed to create a test case for this issue which is failing on the current master branch.
Maybe this is due to some internal difference of the test `Client` when running during tests?

Fixes #180