### PR TITLE
Adapt tests to new urllib exception

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 
+* Improve formatting for `NameResolutionError` (Timo Brembeck, #192)
 * Fix internal redirect checker (Timo Ludwig, #180)
 * Fix SSL status of unreachable domains (Timo Ludwig, #184)
 * Fix URL message for internal server errorrs (Timo Ludwig, #182)

--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -567,6 +567,9 @@ def format_connection_error(e):
     # If the underlying cause is a new connection error, provide additional formatting
     if reason.startswith("NewConnectionError"):
         return format_new_connection_error(reason)
+    # If the underlying cause is a name resolution error, provide additional formatting
+    if reason.startswith("NameResolutionError"):
+        return format_name_resolution_error(reason)
     # If the underlying cause is an SSL error, provide additional formatting
     if reason.startswith("SSLError"):
         return format_ssl_error(reason)
@@ -583,6 +586,19 @@ def format_new_connection_error(reason):
     )
     if connection_reason:
         return f"New Connection Error: {connection_reason[1]}"
+    return reason
+
+
+def format_name_resolution_error(reason):
+    """
+    Helper function to provide better readable output of name resolution errors thrown by urllib3
+    """
+    resolution_reason = re.search(
+        r"NameResolutionError\([\"']<urllib3\.connection\.HTTPSConnection object at 0x[0-9a-f]+>: (.+)[\"']\)",
+        reason,
+    )
+    if resolution_reason:
+        return f"Name Resolution Error: {resolution_reason[1]}"
     return reason
 
 

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -443,7 +443,7 @@ class ExternalCheckTestCase(LiveServerTestCase):
         for attr in [uv.message, uv.get_message, uv.error_message]:
             self.assertEqual(
                 attr,
-                'New Connection Error: Failed to establish a new connection: [Errno -2] Name or service not known',
+                "Name Resolution Error: Failed to resolve 'invalid' ([Errno -2] Name or service not known)",
             )
         self.assertEqual(uv.anchor_message, '')
         self.assertEqual(uv.ssl_status, None)


### PR DESCRIPTION
Apparently, urllib throws a different exception for name resolution errors now, so the tests break on the current master branch.

Unfortunately, I did not find a test server that would cause a `NewConnectionError` now, so we loose a little bit of test coverage with this PR.