### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,8 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         django-version: ['3.2', '4.1', '4.2']
-        exclude:
-        - python-version: '3.7'
-          django-version: '4.1'
-        - python-version: '3.7'
-          django-version: '4.2'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         django-version: ['3.2', '4.1', '4.2']
 
     steps:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Unreleased
 * Fix SSL status of unreachable domains (Timo Ludwig, #184)
 * Fix URL message for internal server errorrs (Timo Ludwig, #182)
 * Add support for Django 4.2
+* Add support for Python 3.12
 * Remove support for Django 4.0
 * Remove support for Python 3.7
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Unreleased
 * Fix URL message for internal server errorrs (Timo Ludwig, #182)
 * Add support for Django 4.2
 * Remove support for Django 4.0
+* Remove support for Python 3.7
 
 2.2.1 (2023-04-03)
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ automatically when objects are saved. This is handled by signals.
 Minimal requirements
 --------------------
 
-django-linkcheck requires Python 3.7 and Django 3.2.
+django-linkcheck requires Python 3.8 and Django 3.2.
 
 Basic usage
 -----------

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
- Remove support for Python 3.7 (reached end-of-life on 2023-06-27)
- Add support for Python 3.12 (released on 2023-10-02)