### PR TITLE
Environment option to skip compilation of translation files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,9 @@ Basic usage
 -----------
 
 #. Install app to somewhere on your Python path (e.g. ``pip install
-   django-linkcheck``).
+   django-linkcheck``). If you do not need multilingual support, you can skip
+   the compilation of the translation files with an environment variable, e.g.
+   (``LINKCHECK_SKIP_TRANSLATIONS=true pip install django-linkcheck``).
 
 #. Add ``'linkcheck'`` to your ``settings.INSTALLED_APPS``.
 

--- a/linkcheck/build_meta.py
+++ b/linkcheck/build_meta.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from setuptools import build_meta as default
@@ -5,17 +6,29 @@ from setuptools.build_meta import *  # noqa: F401, F403
 
 
 def compile_translation_files():
-    print("Compile translation files")
+    print("Compiling translation files...")
     subprocess.run(["django-admin", "compilemessages"], cwd="linkcheck")
 
 
+def should_compile_translation_files():
+    skip_translations = os.environ.get("LINKCHECK_SKIP_TRANSLATIONS")
+    if skip_translations and skip_translations.lower() in ("1", "true", "yes", "t", "y"):
+        return False
+
+    return True
+
+
 def build_sdist(sdist_directory, config_settings=None):
-    compile_translation_files()
+    if should_compile_translation_files():
+        compile_translation_files()
+
     return default.build_sdist(sdist_directory, config_settings)
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    compile_translation_files()
+    if should_compile_translation_files():
+        compile_translation_files()
+
     return default.build_wheel(
         wheel_directory,
         config_settings=config_settings,

--- a/linkcheck/templates/linkcheck/report.html
+++ b/linkcheck/templates/linkcheck/report.html
@@ -171,7 +171,7 @@
                                         </td>
                                     </tr>
                                     {% if link.url.redirect_to %}
-                                        <tr><td colspan="6">R{% translate "Redirects to" %}: <a href="{{ link.url.redirect_to }}" target="_blank">{{ link.url.redirect_to }}</a></td></tr>
+                                        <tr><td colspan="6">{% translate "Redirects to" %}: <a href="{{ link.url.redirect_to }}" target="_blank">{{ link.url.redirect_to }}</a></td></tr>
                                     {% endif %}
                                 {% endfor %}
                             </table>


### PR DESCRIPTION
Added environment option `LINKCHECK_SKIP_TRANSLATIONS` to skip compilation of translation files when they are not needed.
