### PR TITLE
Truncate data urls

### DIFF
--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -96,6 +96,9 @@ def check_instance_links(sender, instance, **kwargs):
 
                 if len(url) > MAX_URL_LENGTH:
                     # We cannot handle url longer than MAX_URL_LENGTH at the moment
+                    if url.startswith("data:"):
+                        # If the URL is a data URL, it might occupy a LOT of space in the logs without being useful – truncate it
+                        url = url[:64]
                     logger.warning('URL exceeding max length will be skipped: %s', url)
                     continue
 

--- a/linkcheck/listeners.py
+++ b/linkcheck/listeners.py
@@ -99,7 +99,7 @@ def check_instance_links(sender, instance, **kwargs):
                     if url.startswith("data:"):
                         # If the URL is a data URL, it might occupy a LOT of space in the logs without being useful – truncate it
                         url = url[:64]
-                    logger.warning('URL exceeding max length will be skipped: %s', url)
+                    logger.warning('URL exceeding max length will be skipped: %s  (in %r)', url, instance)
                     continue
 
                 u, created = Url.objects.get_or_create(url=url)

--- a/linkcheck/utils.py
+++ b/linkcheck/utils.py
@@ -137,7 +137,7 @@ def update_urls(urls, content_type, object_id):
             if url.startswith("data:"):
                 # If the URL is a data URL, it might occupy a LOT of space in the logs without being useful – truncate it
                 url = url[:64]
-            logger.warning("URL exceeding max length will be skipped: %s", url)
+            logger.warning("URL exceeding max length will be skipped: %s  (in %r)", url, instance)
             continue
 
         url, url_created = Url.objects.get_or_create(url=url)

--- a/linkcheck/utils.py
+++ b/linkcheck/utils.py
@@ -134,6 +134,9 @@ def update_urls(urls, content_type, object_id):
 
         if len(url) > MAX_URL_LENGTH:
             # We cannot handle url longer than MAX_URL_LENGTH at the moment
+            if url.startswith("data:"):
+                # If the URL is a data URL, it might occupy a LOT of space in the logs without being useful – truncate it
+                url = url[:64]
             logger.warning("URL exceeding max length will be skipped: %s", url)
             continue
 


### PR DESCRIPTION
Linkcheck **limits URL length to `MAX_URL_LENGTH`**, longer URLs are skipped and a **warning is logged** mentioning the URL. This can create disadvantageous situations:

- Someone decided it was a good idea to put a multi megabyte image directly into the content as a base64 encoded data URL, and the project using django-linkcheck did not think to prevent that situation.
  Now there are multi megabyte data urls  in the log every time linkcheck scans this. **Inspecting logs is near impossible**, since one has to scroll past huge blocks of garbage data, and maybe there's another data url logged just after it, so the important log line between the two is easily missed.

- Maybe it is from a data URL or maybe just a conventional URL that happens to exceed `MAX_URL_LENGTH` – one decides to **investigate where in the content it was used** and whether it should be changed somehow.
  Unfortunately, the usual solution of looking at Link objects to find the content object the URL is in does not work, since the URL was rejected for being too long.

### I propose a solution to each of these:

- If the URL exceeds `MAX_URL_LENGTH`, if it also **starts with `data:`, truncate** it to only 64 characters.
  *(Expectation: the data is not useful for identifying the URL)*

- In the log message when the URL exceeds `MAX_URL_LENGTH`, **also log the instance where it came from** to aid doing something about it.