### PR TITLE
Fall back to GET when HEAD returns 500

### DIFF
--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -410,7 +410,7 @@ class Url(models.Model):
                     # Re-raise exception if it's definitely not a false positive
                     raise
             # If HEAD is not allowed, let's try with GET
-            if response.status_code in [HTTPStatus.BAD_REQUEST, HTTPStatus.METHOD_NOT_ALLOWED]:
+            if response.status_code in [HTTPStatus.BAD_REQUEST, HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.INTERNAL_SERVER_ERROR]:
                 logger.debug("HEAD is not allowed, retry with GET")
                 fetch = requests.get
                 response = fetch(self.external_url, **request_params)

--- a/linkcheck/models.py
+++ b/linkcheck/models.py
@@ -410,7 +410,8 @@ class Url(models.Model):
                     # Re-raise exception if it's definitely not a false positive
                     raise
             # If HEAD is not allowed, let's try with GET
-            if response.status_code in [HTTPStatus.BAD_REQUEST, HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.INTERNAL_SERVER_ERROR]:
+            if response.status_code in [
+                    HTTPStatus.BAD_REQUEST, HTTPStatus.METHOD_NOT_ALLOWED,  HTTPStatus.INTERNAL_SERVER_ERROR]:
                 logger.debug("HEAD is not allowed, retry with GET")
                 fetch = requests.get
                 response = fetch(self.external_url, **request_params)

--- a/linkcheck/tests/test_linkcheck.py
+++ b/linkcheck/tests/test_linkcheck.py
@@ -444,6 +444,23 @@ class ExternalCheckTestCase(LiveServerTestCase):
         self.assertEqual(uv.redirect_to, '')
         self.assertEqual(uv.type, 'external')
 
+    def test_external_check_get_only_500(self):
+        # A server that returns 500 to HEAD but 200 to GET (e.g. Apache/W3TC misconfiguration)
+        # linkcheck should fall back to GET and mark the URL as working.
+        uv = Url(url=f"{self.live_server_url}/http/getonly/500/")
+        uv.check_url()
+        self.assertEqual(uv.message, '200 OK')
+        self.assertEqual(uv.get_message, 'Working external link')
+        self.assertEqual(uv.error_message, '')
+        self.assertEqual(uv.status, True)
+        self.assertEqual(uv.anchor_message, '')
+        self.assertEqual(uv.ssl_status, None)
+        self.assertEqual(uv.ssl_message, 'Insecure link')
+        self.assertEqual(uv.get_status_code_display(), '200 OK')
+        self.assertEqual(uv.get_redirect_status_code_display(), None)
+        self.assertEqual(uv.redirect_to, '')
+        self.assertEqual(uv.type, 'external')
+
     @requests_mock.Mocker()
     def test_external_check_unreachable(self, mocker):
         exc = ConnectionError(


### PR DESCRIPTION
https://github.com/DjangoAdminHackers/django-linkcheck/blob/c13ea894c153d5c18314c4d030f3fb52d499563a/linkcheck/models.py#L413

Some servers return 500 to HEAD requests but 200 to GET. The current fallback only retries with GET on 400 and 405. This adds 500 to that list so those URLs will be rechecked (and not incorrectly marked as broken.)
An example of such a site:
https://swefc.unm.edu/home/resources/?_sft_topic=water-conservation

```sh
# Fails (HEAD request - what linkcheck uses)
curl -I "https://swefc.unm.edu/home/resources/?_sft_topic=water-conservation"

# Succeeds (GET request - what browsers use)
curl -L "https://swefc.unm.edu/home/resources/?_sft_topic=water-conservation"
```

This PR adds `HTTPStatus.INTERNAL_SERVER_ERROR` to the list of status codes that are matched for fallback (current line 413.)
